### PR TITLE
Fixed handling of default copyright file decoding errors.

### DIFF
--- a/QGIS Plugin/templateselectordialog.py
+++ b/QGIS Plugin/templateselectordialog.py
@@ -313,7 +313,7 @@ class TemplateSelectorDialog(QDialog):
 
         defaultFilePath = os.path.join(copyrightFolder, 'default.txt')
         if os.path.isfile(defaultFilePath):
-            with open(defaultFilePath, 'r') as defaultFile:
+            with open(defaultFilePath, 'r', errors='ignore') as defaultFile:
                 defautlCopyright = defaultFile.read().strip()
                 if defautlCopyright.lower().endswith('.txt'):
                     defautlCopyright = defautlCopyright[:-4]


### PR DESCRIPTION
Fixes #19 

Added handling for a case when users put a non-ASCII character into `Copyrights/default.txt` file.